### PR TITLE
Add network policy template to sasidaemon helm chart

### DIFF
--- a/charts/sasi-daemon/templates/networkPolicy.yaml
+++ b/charts/sasi-daemon/templates/networkPolicy.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.networkPolicy.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "application.name" . }}
+  labels:
+    name: {{ template "application.name" . }}
+    chart: {{ template "application.chart" . }}
+    release: {{ .Release.Name }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ template "application.name" . }}
+  {{- if (.Values.networkPolicy.spec).policyTypes }}
+  policyTypes:
+  {{- toYaml .Values.networkPolicy.spec.policyTypes | nindent 4 }}
+  {{- end }}
+  {{- if (.Values.networkPolicy.spec).ingress }}
+  ingress:
+    {{- toYaml .Values.networkPolicy.spec.ingress | nindent 4 }}
+  {{- end }}
+  {{- if (.Values.networkPolicy.spec).egress }}
+  egress:
+    {{- toYaml .Values.networkPolicy.spec.egress | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/sasi-daemon/values.yaml
+++ b/charts/sasi-daemon/values.yaml
@@ -80,6 +80,23 @@ ingress:
 httpPort: "31230"
 daemonPort: "31240"
 
+networkPolicy:
+  enabled: false
+  # spec:
+    # policyTypes:
+    # - Ingress
+    # - Egress
+    # ingress:
+    # - from:
+      # - podSelector:
+          # matchLabels:
+            # app: example
+    # egress:
+    # - to:
+      # - podSelector:
+          # matchLabels:
+            # app: example
+
 tk_sasidaemon_starter: |
       #################################################
       #                                               #


### PR DESCRIPTION
# Description
This MR adds an optional network policy template to the sasidaemon helm chart. The network policy targets the sasidaemon deployment pods.
ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/

## Configuration
The network policy template can be activated by setting the helm value `networkPolicy.enabled=true`.

Policy Types, Ingress and Egress rules for the network policy can be configured via corresponding helm values under `networkPolicy.spec`.

closes #3 